### PR TITLE
Update on scroll

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,14 @@ export default function vhCheck(options) {
     var result = options.method()
     updateCssVar(options.cssVarName, result)
   }
+  
   window.addEventListener('orientationchange', onOrientationChange, false)
+  document.body.addEventListener('touchmove', onOrientationChange, false)
+
   result.unbind = function unbindOrientationchange() {
     window.removeEventListener('orientationchange', onOrientationChange)
+    document.body.removeEventListener('touchmove', onOrientationChange)
   }
+  
   return result
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,16 @@ export default function vhCheck(options) {
   }
   
   window.addEventListener('orientationchange', onOrientationChange, false)
-  document.body.addEventListener('touchmove', onOrientationChange, false)
-
   result.unbind = function unbindOrientationchange() {
     window.removeEventListener('orientationchange', onOrientationChange)
-    document.body.removeEventListener('touchmove', onOrientationChange)
+  }
+
+  if (options.updateOnScroll){
+    document.body.addEventListener('touchmove', onOrientationChange, false)
+    result.unbind = function unbindOrientationchange() {
+      window.removeEventListener('orientationchange', onOrientationChange)
+      document.body.removeEventListener('touchmove', onOrientationChange)
+    }
   }
   
   return result

--- a/src/options.js
+++ b/src/options.js
@@ -8,6 +8,7 @@ var defaultOptions = {
   method: methods.computeDifference,
   force: false,
   autoBind: true,
+  updateOnScroll: false
 }
 
 function isString(value) {


### PR DESCRIPTION
Utilises `touchmove` to call the `updateCssVar` function, this means you won't have to wrap the `vh-check` function in an event listener add more `orientationchanges`.